### PR TITLE
Declare "settingSearch" on Settings

### DIFF
--- a/window.d.ts
+++ b/window.d.ts
@@ -35,6 +35,7 @@ declare interface Settings extends GameWindow {
   tabs: Record<string, SettingsTab[]>;
   settingType: string;
   tabIndex: number;
+  settingSearch: string | null;
 }
 
 // eslint-disable-next-line no-var


### PR DESCRIPTION
Hey @e9x, you forgot the "settingSearch" property on the settings window that may be null, but upon typing in the Krunker search bar it is set to the value of the search input.